### PR TITLE
Display execution info when sourced

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,6 @@ yarepl.setup {
         zsh = '# ',
         lua = '-- ',
     },
-    default_comment_prefix = '# ', -- Fallback comment prefix if a specific one isn't found
 }
 ```
 
@@ -752,7 +751,6 @@ yarepl.formatter.factory {
         zsh = '# ',
         lua = '-- ',
     },
-    default_comment_prefix = '# ', -- Fallback comment prefix if a specific one isn't found
 }
 
 -- `yarepl` provides three builtin formatters that can be referenced by name:

--- a/README.md
+++ b/README.md
@@ -172,6 +172,17 @@ yarepl.setup {
             send_delayed_cr_after_sending = true,
         },
     },
+    print_1st_line_on_source = false, -- If true, sends the first non-empty line of sourced content as a comment
+    comment_prefixes = {
+        -- Defines comment characters for different REPLs
+        python = '# ',
+        ipython = '# ',
+        R = '# ',
+        bash = '# ',
+        zsh = '# ',
+        lua = '-- ',
+    },
+    default_comment_prefix = '# ', -- Fallback comment prefix if a specific one isn't found
 }
 ```
 
@@ -731,6 +742,17 @@ yarepl.formatter.factory {
             join_lines_with_cr = true,
         },
     },
+    print_1st_line_on_source = false, -- If true, sends the first non-empty line of sourced content as a comment
+    comment_prefixes = {
+        -- Defines comment characters for different REPLs
+        python = '# ',
+        ipython = '# ',
+        R = '# ',
+        bash = '# ',
+        zsh = '# ',
+        lua = '-- ',
+    },
+    default_comment_prefix = '# ', -- Fallback comment prefix if a specific one isn't found
 }
 
 -- `yarepl` provides three builtin formatters that can be referenced by name:

--- a/lua/yarepl/init.lua
+++ b/lua/yarepl/init.lua
@@ -46,7 +46,6 @@ local default_config = function()
             zsh = '# ',
             lua = '-- ',
         },
-        default_comment_prefix = '# ', -- Fallback comment prefix if a specific one isn't found
     }
 end
 


### PR DESCRIPTION
An alternative approach  (my personally preferred) when logging the first line of comment and execution time

More discussion https://github.com/milanglacier/yarepl.nvim/pull/31#issuecomment-2926716742 and https://github.com/milanglacier/yarepl.nvim/pull/31#issuecomment-2926873648