### PR TITLE
more robust souce_command match

### DIFF
--- a/lua/yarepl/init.lua
+++ b/lua/yarepl/init.lua
@@ -1035,26 +1035,13 @@ end
 ---@param keep_file boolean?
 ---@reutrn string? The syntax to source the file
 function M.source_file_with_source_syntax(content, source_syntax, keep_file)
-    local tmp_file = os.tmpname() .. '_yarepl'
+    local tmp_file = M.make_tmp_file(content, keep_file)
 
-    local f = io.open(tmp_file, 'w+')
-    if f == nil then
-        M.notify('Cannot open temporary message file: ' .. tmp_file, 'error', vim.log.levels.ERROR)
-        return
+    if not tmp_file then
+        return nil
     end
 
-    f:write(content)
-    f:close()
-
-    if not keep_file then
-        vim.defer_fn(function()
-            os.remove(tmp_file)
-        end, 5000)
-    end
-
-    -- replace {{file}} placeholder with the temp file name
     source_syntax = source_syntax:gsub('{{file}}', tmp_file)
-
     return source_syntax
 end
 

--- a/lua/yarepl/init.lua
+++ b/lua/yarepl/init.lua
@@ -1106,6 +1106,26 @@ M.setup = function(opts)
     end
 end
 
+M.commands.clear_hints = function()
+    local ns_id = M._virt_text_ns_id
+    local cleared_count = 0
+
+    for _, repl in ipairs(M._repls) do
+        -- Check if the REPL buffer is still loaded and valid.
+        if repl_is_valid(repl) then
+            -- Clear all extmarks within our specific namespace for the entire buffer.
+            api.nvim_buf_clear_namespace(repl.bufnr, ns_id, 0, -1)
+            cleared_count = cleared_count + 1
+        end
+    end
+
+    if cleared_count > 0 then
+        vim.notify(string.format('Cleared hints from %d REPL buffer(s).', cleared_count), vim.log.levels.INFO, { title = 'Yarepl' })
+    else
+        vim.notify('No active REPLs found to clear hints from.', vim.log.levels.INFO, { title = 'Yarepl' })
+    end
+end
+
 api.nvim_create_user_command('REPLStart', M.commands.start, {
     count = true,
     bang = true,
@@ -1224,6 +1244,10 @@ api.nvim_create_user_command('REPLExec', M.commands.exec, {
     desc = [[
 Execute a command in REPL `i` or the REPL that current buffer is attached to.
 ]],
+})
+
+api.nvim_create_user_command('REPLClearHints', M.commands.clear_hints, {
+    desc = 'Clear all source command hints from all active REPL buffers.',
 })
 
 return M


### PR DESCRIPTION
There are cases where the source_command spawned into multiple lines within REPL so the virtual_text function fails to match. This PR uses `tmp_file_anchor` for a more robust match algo. 

![image](https://github.com/user-attachments/assets/13fcb799-b3ae-4f2f-9217-f4af557c3f4f)

![image](https://github.com/user-attachments/assets/525928e5-b193-4e32-bfff-65c5a587a7b4) 
(this problem is more common on windows as the path to `$HOME` is significantly longer)


On top, adding a REPLClearHints command that allows user the clean the source hints. 