### PR TITLE
Safely handle aborted motions or missing, empty, or inverted ranges

### DIFF
--- a/lua/yarepl/init.lua
+++ b/lua/yarepl/init.lua
@@ -337,6 +337,15 @@ local function get_lines(mode, submode)
     local end_line = end_pos[2]
     local end_col = end_pos[3]
 
+    if
+        begin_line == 0
+        or end_line == 0
+        or begin_line > end_line
+        or (begin_line == end_line and begin_col > end_col)
+    then
+        return {}
+    end
+
     if submode == 'char' or submode == 'v' then
         local lines = api.nvim_buf_get_text(0, begin_line - 1, begin_col - 1, end_line - 1, -1, {})
         if #lines > 0 and #lines[#lines] > 0 then


### PR DESCRIPTION
I have been using yarepl with leap.nvim which help me select by treesitter obj. Upon canceling a selection / motion, yarepl would yields `index out of range` error which i want to avoid
<img width="1091" height="98" alt="image" src="https://github.com/user-attachments/assets/b6a42396-4067-4d40-9b65-be75be498707" />
 
 thank you!